### PR TITLE
Automate releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+on:
+  push:
+    branches: [main]
+    tags: ["*"]
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - uses: olafurpg/setup-scala@v13
+      - run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ You can see all the notable changes in [CHANGELOG](CHANGELOG.md).
 
 [CONTRIBUTING](CONTRIBUTING.md) might help us.
 
+
+## For Maintainers
+
+[RELEASING](RELEASING.md) describes how to release a new version.
+
+
 ## License
 
 akka-coordinator-avoidance-shard-allocation-strategy is released under the terms of the [Apache License Version 2.0](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ You have to add a dependency into your project to use this library.
 Add the following lines to your `build.sbt` file:
 
 **Stable Release (Not Available)**  
+[![Maven Central](https://img.shields.io/maven-central/v/com.lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy_2.13?color=%23005cb2&label=stable)](https://mvnrepository.com/artifact/com.lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy)  
 Replace `"X.Y.Z"` with the actual version you want to use.
 ```scala
 libraryDependencies += "com.lerna-stack" %% "akka-coordinator-avoidance-shard-allocation-strategy" % "X.Y.Z"
 ```
 
-**Unstable Release (SNAPSHOT, Not Available)**  
+**Unstable Release (SNAPSHOT)**  
+[![Sonatype Nexus (Snapshots)](https://img.shields.io/nexus/s/com.lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy_2.13?color=%237B1FA2&label=unstable&server=https%3A%2F%2Foss.sonatype.org)](https://oss.sonatype.org/index.html#nexus-search;gav~com.lerna-stack~akka-coordinator-avoidance-shard-allocation-strategy_*~~~)  
 Replace `"X.Y.Z"` with the actual version you want to use.
 ```scala
 // You have to refer to Sonatype if you use a snapshot version.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,70 @@
+# Releasing
+
+This document describes how to release a new version `X.Y.Z` for maintainers.
+It would be required to replace `X.Y.Z` with the actual release version.
+
+## 1. Create a new branch
+
+Create a new branch `release/vX.Y.Z` from `main` branch like the following:
+```shell
+git checkout main
+git pull origin
+git checkout -b release/vX.Y.Z
+```
+
+## 2. Update `CHANGELOG.md`
+
+1. Add a section of the new release version `vX.Y.Z`  
+    We recommend you add one of the following links to this section.
+    * `https://github.com/lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy/compare/vA.B.C...vX.Y.Z` if this release is a successor.
+      * `A.B.C` is the previous latest version.
+    * `https://github.com/lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy/tree/vX.Y.Z` if this release is the first one.
+2. Update the unreleased version link to `https://github.com/lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy/compare/vX.Y.Z...main`
+
+## 3. Commit & Push
+
+Commit changes, and then push the branch like the following:
+```shell
+git commit --message 'release vX.Y.Z'
+git push origin
+```
+
+## 4. Create a Pull Request
+
+After committing and pushing all changes, create a pull request.
+Other maintainers will review and merge the pull request.
+
+## 5. Push a new version tag `vX.Y.Z`
+
+*It is highly recommended ensuring that the new version tag is correct.*  
+*The CI will automatically publish this release when detecting the version tag.*
+
+Create and push the new version tag `vX.Y.Z` like the following:
+```shell
+git checkout main
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+## 6. Check the release is available
+
+Check the release is available at [Maven Central Repository](https://repo1.maven.org/maven2/com/lerna-stack/).
+
+**NOTE**
+- The release will be available about 10 minutes after publishing.
+- It requires more time to be able to find the release with searching (about 2 hours max).
+
+## 7. Create a new release `vX.Y.Z`
+
+Create a new release `vX.Y.Z` from [this link](https://github.com/lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy/releases/new).
+
+- **Choose a tag**: select the new version tag
+- **Release title**: the same as the tag
+- **Describe this release**:  
+    Write the following text, at least.  
+    Replace the part `#vXYZ---YYYY-MM-DD` of the link with the actual release version and date.
+    ```markdown
+    See [CHANGELOG] for details.
+  
+    [CHANGELOG]: https://github.com/lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy/blob/main/CHANGELOG.md#vXYZ---YYYY-MM-DD
+    ```

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.2")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")


### PR DESCRIPTION
By using sbt-ci-release:
https://github.com/sbt/sbt-ci-release

TODO:
* [x] Adopt sbt-ci-release
* [x] Test publishing
* [x] Update README.md
* [x] Write RELEASING.md

### Adopt sbt-ci-release

I've followed install steps described at https://github.com/sbt/sbt-ci-release.
I've also made sure the following items:
* `build.sbt` and `publish.sbt` don't define any of the following settings:
  * `version`
  * `publishTo`
  * `publishMavenStyle`
  * `credentials`
* The default value of `CI_RELEASE`, `CI_SNAPSHOT_RELEASE`, and `CI_SONATYPE_RELEASE` make sense for this project.

#### Add repository secrets

I've create a new gpg key for this project.
We can find the created gpg public key at
[keys.openpgp.org](https://keys.openpgp.org/search?q=C77497D1B178E04EAFE5F5E25D0B94B7ACD9CD1A).

I've added `PGP_PASSPHRASE` and `PGP_SECRET` as repository secrets, which is noted [here](https://github.com/sbt/sbt-ci-release#secrets).
We can see these items at [Actions secrets](https://github.com/lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy/settings/secrets/actions).

### Test
We can see publishing and the released snapshot version the below links.
* [[DONT MERGE] Test publishing snapshot by xirc · Pull Request #6 · lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy](https://github.com/lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy/pull/6)
* [Test publising snapshot · lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy@0e4410e](https://github.com/lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy/runs/4555340455?check_suite_focus=true)
* [Index of /repositories/snapshots/com/lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy_2.13/0.0.0+10-0e4410e0-SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/com/lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy_2.13/0.0.0+10-0e4410e0-SNAPSHOT/)