### PR TITLE
Add olafurpg/setup-gpg@v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v13
+      - uses: olafurpg/setup-gpg@v3
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
The publish failed (https://github.com/lerna-stack/akka-coordinator-avoidance-shard-allocation-strategy/runs/5672758311). This might be due to something related to `gpg`.

Other repositories uses `olafurpg/setup-gpg@v3`:
* https://github.com/lerna-stack/akka-entity-replication/blob/abe3af97c2e00ef2d75a23d83c6f045d74fdc904/.github/workflows/release.yml#L14
* https://github.com/lerna-stack/lerna-app-library/blob/796a5054116ac3c41013cb0fa3cd9f699af60212/.github/workflows/release.yml#L14