### PR TITLE
Use MiMa to ensure binary compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Fetch all history for all tags and branches.
+          # sbt-dynver detects the previous version by git tag.
+          # Mima uses the detected previous version to ensure binary compatibility.
+          fetch-depth: 0
+
       - uses: coursier/cache-action@v6
 
       - name: Set up JDK ${{ matrix.java }}
@@ -33,6 +39,9 @@ jobs:
       # Detect compile errors early
       - name: Compile
         run: sbt clean compile Test/compile
+
+      - name: Check binary compartibility
+        run: sbt mimaReportBinaryIssues
 
       - name: Test
         run: sbt coverage test

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,14 @@ ThisBuild / coverageFailOnMinimum := true
 ThisBuild / coverageMinimumStmtTotal := 80
 ThisBuild / coverageMinimumBranchTotal := 80
 
+// MiMa
+ThisBuild / mimaPreviousArtifacts := {
+  previousStableVersion.value
+    .map(organization.value %% moduleName.value % _)
+    .toSet
+}
+ThisBuild / mimaReportSignatureProblems := true
+
 lazy val root =
   (project in file("."))
     .settings(
@@ -34,8 +42,14 @@ lazy val root =
 
 addCommandAlias(
   "ci",
-  Seq("clean", "scalafmtSbtCheck", "scalafmtCheckAll", "Test/compile", "test")
-    .mkString(";")
+  Seq(
+    "clean",
+    "scalafmtSbtCheck",
+    "scalafmtCheckAll",
+    "Test/compile",
+    "mimaReportBinaryIssues",
+    "test"
+  ).mkString(";")
 )
 
 addCommandAlias(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.2")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.0.1")


### PR DESCRIPTION
Closes #7 

MiMa ensures binary compatibility on CI.

If there is binary incompatibility, CI will fail (#11).
If `mima-filters` excludes such binary incompatibility, CI will succeed (#12).
